### PR TITLE
Move old site address to the new site address

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
   <img src="https://raw.githubusercontent.com/rescriptbr/ancestor/master/assets/ancestor-logo.svg" /> 
   <br />
   <br />
-  <a target="_blank" href="https://ancestor.rescriptbrasil.org"> Docs </a> //
-    <a target="_blank" href="https://ancestor.rescriptbrasil.org/docs/getting-started"> Getting Started </a> //
+  <a target="_blank" href="https://ancestor.netlify.app"> Docs </a> //
+    <a target="_blank" href="https://ancestor.netlify.app/docs/getting-started"> Getting Started </a> //
   <a target="_blank" href="https://github.com/rescriptbr"> ReScript Brazil Community </a>
  </p>
 


### PR DESCRIPTION
I talked to @vmascosp last week, and he said that Ancestor would not use the site address https://ancestor.rescriptbrasil.org anymore, but https://ancestor.netlify.app